### PR TITLE
Only clear timeouts added after module load

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+vNEXT / 2016-06-13
+==================
+
+  * Override `global.setTimeout` with a listener that explicitly tracks IDs, and only clear timeouts that are pending since installing the listener
+
 1.0.0 / 2016-05-30
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,37 +1,56 @@
 'use strict';
 
-/**
- * Previous
- */
+// XXX(ndhoule): Handle on Function#apply to get around IE7/8 ghettry
+var apply = Function.prototype.apply;
 
-var prev = 0;
+// Keep a handle on original timer globals
+var nativeSetTimeout = global.setTimeout;
+var nativeClearTimeout = global.clearTimeout;
 
-/**
- * Noop
- */
-
-var noop = Function.prototype;
+// Track a list of timeout IDs
+var timeoutIds = [];
 
 /**
- * Clear all timeouts
- *
- * @api public
+ * Clear a list of setTimeout timer IDs.
  */
-
 function clearTimeouts() {
-  var tmp;
-  var i;
-
-  tmp = i = setTimeout(noop);
-  while (prev < i) {
-    clearTimeout(i--);
+  for (var i = 0; i < timeoutIds.length; i += 1) {
+    nativeClearTimeout(timeoutIds[i]);
   }
-  prev = tmp;
+
+  // Reset the list of tracked timeout IDs
+  timeoutIds.length = 0;
 }
 
+/**
+ * Override `global.setTimeout` with a function that tracks all setTimeout timer
+ * IDs and then delegates to `global.setTimeout`.
+ *
+ * Note that any timeouts that were in effect prior to installing the tracker will *not* be cleared.
+ *
+ * @param {Object} [context=global] The context to override `setTimeout` in.
+ */
+function installMockSetTimeout(context) {
+  context = context || global;
+  // Reset the list of tracked timeout IDs
+  timeoutIds.length = 0;
+
+  // IE7/8: Move setTimeout off proto and onto instance
+  global.setTimeout = global.setTimeout;
+  global.setTimeout = function setTimeout() {
+    // XXX(ndhoule): IE7/8 are ghetto so setTimeout.proto !== Function.proto
+    var id = apply.call(nativeSetTimeout, global, arguments);
+    timeoutIds.push(id);
+    return id;
+  };
+}
+
+// Automatically override `global.setTimeout` and start tracking timeout IDs
+installMockSetTimeout();
 
 /*
  * Exports.
  */
 
 module.exports = clearTimeouts;
+module.exports.install = installMockSetTimeout;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ describe('clear-timeouts', function() {
   it('should clear timeouts', function(done) {
     setTimeout(function() {
       clear();
-      assert(j === 2);
+      assert.strictEqual(j, 2);
       done();
     }, 51);
   });
@@ -23,7 +23,7 @@ describe('clear-timeouts', function() {
     setTimeout(incr, 50);
     setTimeout(function() {
       clear();
-      assert(j === 3);
+      assert.strictEqual(j, 3);
       done();
     }, 101);
   });


### PR DESCRIPTION
This commit changes this module to override `global.setTimeout` with a
listener that explicitly tracks IDs, and only clear timeouts that were
added after the listener was installed.

This lets us avoid clearing timeouts that Karma/Mocha/etc. need to operate.
